### PR TITLE
Implement lava behavior for fire power

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,14 +54,41 @@ class Actor {
 }
 
 class Player extends Actor {
+    constructor(x, y, stage) {
+        super(x, y, stage);
+        this.powered = false;
+        this.firePower = false;
+    }
     move(dx, dy) {
         const nx = this.x + dx;
         const ny = this.y + dy;
         const target = this.stage.grid[ny] && this.stage.grid[ny][nx];
         if (!target) {
             if (this.stage.isOpen(nx, ny)) this.stage.moveActor(this, nx, ny);
+        } else if (target instanceof FireBox) {
+            this.stage.removeActor(target);
+            this.firePower = true;
+            this.stage.moveActor(this, nx, ny);
+        } else if (target instanceof PowerBox) {
+            this.stage.removeActor(target);
+            this.powered = true;
+            this.stage.moveActor(this, nx, ny);
+        } else if (target instanceof Monster && this.powered) {
+            this.stage.removeActor(target);
+            const pb = this.stage.grid[ny][nx];
+            if (pb instanceof PowerBox) this.stage.removeActor(pb);
+            this.stage.moveActor(this, nx, ny);
+        } else if (target instanceof Monster) {
+            alert('You were caught!');
+            window.location.reload();
+        } else if (target instanceof LavaBox) {
+            alert('You fell in lava!');
+            window.location.reload();
         } else if (target instanceof Box && target.movable) {
             if (this.stage.pushBox(target, dx, dy)) {
+                if (this.firePower) {
+                    this.stage.transformToLava(target);
+                }
                 this.stage.moveActor(this, nx, ny);
             }
         }
@@ -75,11 +102,21 @@ class Monster extends Actor {
         const nx = this.x + dx;
         const ny = this.y + dy;
         if (this.stage.player && nx === this.stage.player.x && ny === this.stage.player.y) {
-            alert('You were caught!');
-            window.location.reload();
+            if (this.stage.player.powered) {
+                this.stage.removeActor(this);
+                return;
+            } else {
+                alert('You were caught!');
+                window.location.reload();
+                return;
+            }
+        }
+        const target = this.stage.grid[ny] && this.stage.grid[ny][nx];
+        if (target instanceof LavaBox) {
+            this.stage.removeActor(this);
             return;
         }
-        if (this.stage.isOpen(nx, ny)) {
+        if (!target || this.stage.isOpen(nx, ny)) {
             this.stage.moveActor(this, nx, ny);
         }
     }
@@ -92,11 +129,21 @@ class FollowMonster extends Monster {
         const nx = this.x + dx;
         const ny = this.y + dy;
         if (this.stage.player && nx === this.stage.player.x && ny === this.stage.player.y) {
-            alert('You were caught!');
-            window.location.reload();
+            if (this.stage.player.powered) {
+                this.stage.removeActor(this);
+                return;
+            } else {
+                alert('You were caught!');
+                window.location.reload();
+                return;
+            }
+        }
+        const target = this.stage.grid[ny] && this.stage.grid[ny][nx];
+        if (target instanceof LavaBox) {
+            this.stage.removeActor(this);
             return;
         }
-        if (this.stage.isOpen(nx, ny)) {
+        if (!target || this.stage.isOpen(nx, ny)) {
             this.stage.moveActor(this, nx, ny);
         }
     }
@@ -111,6 +158,24 @@ class Box extends Actor {
     constructor(x, y, stage, movable = true) {
         super(x, y, stage);
         this.movable = movable;
+    }
+}
+
+class PowerBox extends Box {
+    constructor(x, y, stage) {
+        super(x, y, stage, true);
+    }
+}
+
+class FireBox extends Box {
+    constructor(x, y, stage) {
+        super(x, y, stage, true);
+    }
+}
+
+class LavaBox extends Box {
+    constructor(x, y, stage) {
+        super(x, y, stage, false);
     }
 }
 
@@ -141,12 +206,22 @@ class Stage {
         actor.setCoords(nx, ny);
         this.grid[ny][nx] = actor;
     }
+
+    transformToLava(box) {
+        this.removeActor(box);
+        const lava = new LavaBox(box.x, box.y, this);
+        this.addActor(lava);
+    }
     pushBox(box, dx, dy) {
         const nx = box.x + dx;
         const ny = box.y + dy;
         if (!this.withinBounds(nx, ny)) return false;
         const target = this.grid[ny][nx];
         if (target) {
+            if (target instanceof LavaBox) {
+                this.removeActor(box);
+                return true;
+            }
             if (target instanceof Box && target.movable && this.pushBox(target, dx, dy)) {
                 this.moveActor(box, nx, ny);
                 return true;
@@ -161,6 +236,13 @@ class Stage {
         actor.dead = true;
         const idx = this.actors.indexOf(actor);
         if (idx >= 0) this.actors.splice(idx, 1);
+        if (actor instanceof FireMonster) {
+            const fb = new FireBox(actor.x, actor.y, this);
+            this.addActor(fb);
+        } else if (actor instanceof Monster) {
+            const pb = new PowerBox(actor.x, actor.y, this);
+            this.addActor(pb);
+        }
     }
     monsterTrapped(monster) {
         const dirs = [[1,0],[-1,0],[0,1],[0,-1]];
@@ -253,13 +335,16 @@ function draw(){
             const td = document.createElement('td');
             const cell = stage.grid[y][x];
             const img = document.createElement('img');
-            if (cell instanceof Player) img.src = 'icons/player.jpg';
+            if (cell instanceof Player) img.src = cell.firePower ? 'icons/flames.jpg' : (cell.powered ? 'icons/slayer.jpg' : 'icons/player.jpg');
             else if (cell instanceof FollowMonster) img.src = 'icons/Monsters/follow_monster.png';
             else if (cell instanceof EarthMonster) img.src = 'icons/Monsters/earth_monster.png';
             else if (cell instanceof FireMonster) img.src = 'icons/Monsters/fire_monster.png';
             else if (cell instanceof IceMonster) img.src = 'icons/Monsters/ice_monster.png';
             else if (cell instanceof WindMonster) img.src = 'icons/Monsters/wind_monster.png';
             else if (cell instanceof Monster) img.src = 'icons/Monsters/monster.png';
+            else if (cell instanceof FireBox) img.src = 'icons/Boxes/fire_box.png';
+            else if (cell instanceof LavaBox) img.src = 'icons/Boxes/lava.png';
+            else if (cell instanceof PowerBox) img.src = 'icons/Boxes/monster_disguise.png';
             else if (cell instanceof Box) img.src = cell.movable ? 'icons/Boxes/box.png' : 'icons/Boxes/wall.png';
             else img.src = 'icons/blank.png';
             td.appendChild(img);


### PR DESCRIPTION
## Summary
- add firePower to player and detect FireBox pickups
- create FireBox and LavaBox classes
- drop FireBox when FireMonsters die
- convert pushed boxes into lava when fire-powered
- lava kills monsters and players on contact
- render flames for fire-powered player and new box types

## Testing
- `git status --short`
- `git log -1 --stat`
